### PR TITLE
Add PosterCard and PosterGrid

### DIFF
--- a/src/api/APIUtils.js
+++ b/src/api/APIUtils.js
@@ -1,0 +1,18 @@
+/**
+ * This file contains helper functions to use TheMovieDB API
+ */
+
+const baseImgUrl = "https://image.tmdb.org/t/p/";
+
+/**
+ * Takes the poster_path or backdrop_path value from the API and an optional
+ * size parameter and returns the full image URL.
+ * See https://api.themoviedb.org/3/configuration?api_key=YOURKEY for
+ * examples of image sizes
+ */
+export const getFullImgPath = (imgPath, size = "original") => `${baseImgUrl}${size}${imgPath}`;
+
+/**
+ * Takes a full date in the format YYYY-MM-DD and returns the year
+ */
+export const getYearFromDate = fullDate => fullDate.substring(0, 4);

--- a/src/components/PosterCard.js
+++ b/src/components/PosterCard.js
@@ -5,21 +5,26 @@ import { getFullImgPath, getYearFromDate } from "../api/APIUtils";
 import "../css/PosterCard.scss";
 
 function PosterCard({ title, posterPath, linkTo, releaseDate }) {
+  const releaseYear = releaseDate ? ` (${getYearFromDate(releaseDate)})` : "";
   return (
     <Link className="poster-card" to={linkTo}>
       <img className="poster" src={getFullImgPath(posterPath, "w342")} alt={title} />
       <p className="title">
-        {title} ({getYearFromDate(releaseDate)})
+        {title}{releaseYear}
       </p>
     </Link>
   );
 }
 
+PosterCard.defaultProps = {
+  releaseDate: "",
+};
+
 PosterCard.propTypes = {
   title: PropTypes.string.isRequired,
   posterPath: PropTypes.string.isRequired,
   linkTo: PropTypes.string.isRequired,
-  releaseDate: PropTypes.string.isRequired,
+  releaseDate: PropTypes.string,
 };
 
 export default PosterCard;

--- a/src/components/PosterCard.js
+++ b/src/components/PosterCard.js
@@ -1,0 +1,25 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
+import { getFullImgPath, getYearFromDate } from "../api/APIUtils";
+import "../css/PosterCard.scss";
+
+function PosterCard({ title, posterPath, linkTo, releaseDate }) {
+  return (
+    <Link className="poster-card" to={linkTo}>
+      <img className="poster" src={getFullImgPath(posterPath, "w342")} alt={title} />
+      <p className="title">
+        {title} ({getYearFromDate(releaseDate)})
+      </p>
+    </Link>
+  );
+}
+
+PosterCard.propTypes = {
+  title: PropTypes.string.isRequired,
+  posterPath: PropTypes.string.isRequired,
+  linkTo: PropTypes.string.isRequired,
+  releaseDate: PropTypes.string.isRequired,
+};
+
+export default PosterCard;

--- a/src/components/PosterGrid.js
+++ b/src/components/PosterGrid.js
@@ -1,0 +1,27 @@
+import React from "react";
+import PropTypes from "prop-types";
+import PosterCard from "./PosterCard";
+import "../css/PosterGrid.scss";
+
+function PosterGrid({ movies, type }) {
+  return (
+    <div className="poster-grid">
+      {movies.map(movie => (
+        <PosterCard
+          key={movie.id}
+          linkTo={`/${type}/${movie.id}`}
+          title={movie.title}
+          posterPath={movie.poster_path}
+          releaseDate={movie.release_date}
+        />
+      ))}
+    </div>
+  );
+}
+
+PosterGrid.propTypes = {
+  movies: PropTypes.arrayOf(PropTypes.object).isRequired,
+  type: PropTypes.oneOf(["movie", "tv"]).isRequired,
+};
+
+export default PosterGrid;

--- a/src/css/PosterCard.scss
+++ b/src/css/PosterCard.scss
@@ -1,0 +1,16 @@
+.poster-card {
+  display: block;
+  width: 130px;
+  text-align: center;
+  color: inherit;
+  text-decoration: none;
+
+  .poster {
+    width: 100%;
+    box-shadow: 0 4px 7px rgba(black, 0.5);
+  }
+
+  .title {
+    margin: 10px 0 0 0;
+  }
+}

--- a/src/css/PosterGrid.scss
+++ b/src/css/PosterGrid.scss
@@ -1,0 +1,5 @@
+.poster-grid {
+  display: grid;
+  grid-gap: 20px 40px;
+  grid-template-columns: repeat(auto-fit, 130px);
+}


### PR DESCRIPTION
This PR contains two components, PosterCard and PosterGrid. See attached screenshot of how they look. The release year is optional/can choose not to show it.

The font doesn't match our mockup, but we should set the font globally in some other PR.

![image](https://user-images.githubusercontent.com/16100194/38467426-ae75d436-3b38-11e8-9b50-fdc179675361.png)

fixes #10 
fixes #11 
