### PR TITLE
Scrollfix

### DIFF
--- a/src/components/ScrollToTop.js
+++ b/src/components/ScrollToTop.js
@@ -9,12 +9,16 @@ import PropTypes from "prop-types";
 class ScrollToTop extends Component {
   static propTypes = {
     location: PropTypes.object.isRequired,
+    history: PropTypes.object.isRequired,
     children: PropTypes.node.isRequired,
   }
 
   componentDidUpdate(prevProps) {
     if (this.props.location !== prevProps.location) {
-      window.scrollTo(0, 0);
+      // action is POP when the user goes back in their browser
+      if (this.props.history.action !== "POP") {
+        window.scrollTo(0, 0);
+      }
     }
   }
 

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -23,6 +23,16 @@ class App extends Component {
   state = {
     lists: [],
     sidebarIsOpen: false, // only affects mobile
+    nowPlayingMovies: [],
+    nowAiringTVShows: [],
+  }
+
+  setNowPlayingMovies = (nowPlayingMovies) => {
+    this.setState({ nowPlayingMovies });
+  }
+
+  setNowAiringTVShows = (nowAiringTVShows) => {
+    this.setState({ nowAiringTVShows });
   }
 
   toggleSidebar = () => {
@@ -34,7 +44,7 @@ class App extends Component {
   }
 
   render() {
-    const { lists, sidebarIsOpen } = this.state;
+    const { lists, sidebarIsOpen, nowPlayingMovies, nowAiringTVShows } = this.state;
     const sidebarOverlay = (
       <div
         id="overlay"
@@ -55,7 +65,17 @@ class App extends Component {
 
         <div id="main-container">
           <Switch>
-            <Route exact path="/" component={HomepageContainer} />
+            <Route
+              exact
+              path="/"
+              render={() => (
+                <HomepageContainer
+                  movies={nowPlayingMovies}
+                  series={nowAiringTVShows}
+                  setNowPlayingMovies={this.setNowPlayingMovies}
+                  setNowAiringTVShows={this.setNowAiringTVShows}
+                />)}
+            />
             <Route render={() => <div>404</div>} />
           </Switch>
         </div>

--- a/src/containers/HomepageContainer.js
+++ b/src/containers/HomepageContainer.js
@@ -1,28 +1,36 @@
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { getNowPlayingMovies, getNowAiringTVShows } from "../api/APIUtils";
 import Homepage from "../components/Homepage";
 
 class HomepageContainer extends Component {
-  state = {
-    movies: [],
-    series: [],
+  static propTypes = {
+    movies: PropTypes.array.isRequired,
+    series: PropTypes.array.isRequired,
+    setNowPlayingMovies: PropTypes.func.isRequired,
+    setNowAiringTVShows: PropTypes.func.isRequired,
   }
 
   componentDidMount() {
+    const { movies: m, series: s } = this.props;
+    if (m.length !== 0 && s.length !== 0) return;
+
     getNowPlayingMovies()
       .then((movies) => {
-        this.setState({ movies: movies.splice(0, 18) });
+        this.props.setNowPlayingMovies(movies.splice(0, 18));
       }).catch(error => console.log(error)); // TODO: fix better error handling
 
     getNowAiringTVShows()
       .then((series) => {
-        this.setState({ series: series.splice(0, 18) });
+        this.props.setNowAiringTVShows(series.splice(0, 18));
       }).catch(error => console.log(error)); // TODO: fix better error handling here too xD
   }
 
   render() {
+    const { movies, series } = this.props;
+    if (!movies || !series) return null;
     return (
-      <Homepage movies={this.state.movies} series={this.state.series} />
+      <Homepage movies={this.props.movies} series={this.props.series} />
     );
   }
 }

--- a/src/css/PosterCard.scss
+++ b/src/css/PosterCard.scss
@@ -7,6 +7,8 @@
 
   .poster {
     width: 100%;
+    height: 195px;
+    object-fit: cover;
     box-shadow: 0 4px 7px rgba(black, 0.5);
   }
 


### PR DESCRIPTION
This PR moves the state in `HomepageContainer` to `App` in order to preserve the data while browsing other pages. This means that no further API requests are done when the user goes back to the home page, which means that the scroll position is saved.

fixes #28 