### PR TITLE
Add polyfills for fetch and URLSearchParams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11693,6 +11693,11 @@
         }
       }
     },
+    "url-search-params-polyfill": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-3.0.0.tgz",
+      "integrity": "sha512-oRNWuBkJ/zKKK1aiBaTBZTf07zOKd0g+nJYB+vFNPO14gFjA75BaHgIJLtveWBRxI/2qff7xcTb9H6wkpTmqjg=="
+    },
     "url-to-options": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "webpack-dev-server --open --hot --inline --host 0.0.0.0",
+    "start": "webpack-dev-server --open --hot --inline",
     "build": "NODE_ENV=production webpack"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "webpack-dev-server --open --hot --inline",
+    "start": "webpack-dev-server --open --hot --inline --host 0.0.0.0",
     "build": "NODE_ENV=production webpack"
   },
   "repository": {
@@ -50,6 +50,8 @@
     "prop-types": "^15.6.1",
     "react": "^16.3.1",
     "react-dom": "^16.3.1",
-    "react-router-dom": "^4.2.2"
+    "react-router-dom": "^4.2.2",
+    "url-search-params-polyfill": "^3.0.0",
+    "whatwg-fetch": "^2.0.4"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,6 @@
+import "babel-polyfill"; // async await
+import "whatwg-fetch"; // fetch polyfill
+import "url-search-params-polyfill"; // URLSearchParams polyfill
 import "normalize.css";
 import React from "react";
 import ReactDOM from "react-dom";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,7 @@ const publicPath = "/";
 
 // common config options for both dev and prod
 const config = {
-  entry: ["babel-polyfill", "./src/index.js"],
+  entry: "./src/index.js",
   output: {
     path: path.resolve(__dirname, outputDirName),
     filename: jsBundleName,


### PR DESCRIPTION
As the title says.
These polyfills are necessary to prevent the app to crash on devices/browsers not supporting fetch and URLSearchParams (for example pre-iOS 10.3 devices).

fixes #49 