### PR TITLE
Fix search bug

### DIFF
--- a/src/containers/SearchpageContainer.js
+++ b/src/containers/SearchpageContainer.js
@@ -18,6 +18,20 @@ class SearchpageContainer extends Component {
     setSearchResults: PropTypes.func.isRequired,
   }
 
+  static getDerivedStateFromProps(props) {
+    // is true if the user arrives at the search page by backing from
+    // the details page of a search result
+    if (props.history.action === "POP" && props.searchResults.results.length !== 0) {
+      const url = new URLSearchParams(props.location.search);
+      const query = url.get("query");
+
+      // set the query state so componentDidUpdate isn't triggered when
+      // loadMoreAndAppend is called for the first time
+      return { query };
+    }
+    return null;
+  }
+
   state = {
     query: "",
     isLoading: false,


### PR DESCRIPTION
The error was that `this.state.query` turned out to be `undefined` when the user arrived at the search page by backing, since `this.state.query` is set when performing a search.

fixes #63 