### PR TITLE
Better fallbacks when no image

### DIFF
--- a/src/components/DetailsBanner.js
+++ b/src/components/DetailsBanner.js
@@ -1,29 +1,26 @@
 import React from "react";
 import PropTypes from "prop-types";
-import FontAwesomeIcon from "@fortawesome/react-fontawesome";
-import { getFullImgPath } from "../api/APIUtils";
+import ImageWithFallback from "./ImageWithFallback";
 import "../css/DetailsBanner.scss";
 
 /**
  * The backdrop banner for the movie details page
  */
 function DetailsBanner({ backdropPath }) {
-  if (backdropPath === null) {
-    return (
-      <div className="no-poster2">
-        <FontAwesomeIcon icon="image" />
-      </div>);
-  }
   return (
     <div id="banner">
-      <img src={getFullImgPath(backdropPath)} alt="banner of movie" />
+      <ImageWithFallback className="banner-img" src={backdropPath} />
       <div className="gradient" />
     </div>
   );
 }
 
+DetailsBanner.defaultProps = {
+  backdropPath: "",
+};
+
 DetailsBanner.propTypes = {
-  backdropPath: PropTypes.string.isRequired,
+  backdropPath: PropTypes.string,
 };
 
 export default DetailsBanner;

--- a/src/components/DetailsTitle.js
+++ b/src/components/DetailsTitle.js
@@ -2,9 +2,10 @@ import React from "react";
 import PropTypes from "prop-types";
 import moment from "moment-mini";
 import FontAwesomeIcon from "@fortawesome/react-fontawesome";
-import { getFullImgPath, getYearFromDate } from "../api/APIUtils";
+import { getFullImgPath } from "../api/APIUtils";
 import minutesToHours from "../utils/minutesToHours";
 import PrimaryButton from "./PrimaryButton";
+import ImageWithFallback from "./ImageWithFallback";
 import "../css/DetailsTitle.scss";
 
 /**
@@ -30,9 +31,11 @@ function DetailsTitle({ movie, onBtnClick }) {
   } = movie;
 
   let infoLine;
+  let isMovie = false;
 
   // if title is defined, it's a movie
   if (title) {
+    isMovie = true;
     infoLine = (
       <div className="info">
         {
@@ -69,7 +72,13 @@ function DetailsTitle({ movie, onBtnClick }) {
 
   return (
     <div className="details-title">
-      <img className="poster" src={getFullImgPath(posterPath, "w500")} alt={title} />
+      <ImageWithFallback
+        className="poster"
+        src={posterPath}
+        imgSize="w500"
+        alt={`Poster for ${title}`}
+        mediaType={isMovie ? "movie" : "tv"}
+      />
       <div className="text">
         <h1 className="title">{`${displayName} (${moment(displayDate).format("YYYY")})`}</h1>
         <div className="info">

--- a/src/components/ImageWithFallback.js
+++ b/src/components/ImageWithFallback.js
@@ -37,13 +37,14 @@ ImageWithFallback.defaultProps = {
   imgSize: "original",
   alt: "",
   className: "",
+  mediaType: "",
 };
 
 ImageWithFallback.propTypes = {
   src: PropTypes.string,
   /* imgSize examples: "w342", "w500" etc */
   imgSize: PropTypes.string,
-  mediaType: PropTypes.oneOf(["movie", "tv", "person", ""]).isRequired,
+  mediaType: PropTypes.oneOf(["movie", "tv", "person", ""]),
   alt: PropTypes.string,
   className: PropTypes.string,
 };

--- a/src/components/ImageWithFallback.js
+++ b/src/components/ImageWithFallback.js
@@ -1,0 +1,51 @@
+import React from "react";
+import PropTypes from "prop-types";
+import FontAwesomeIcon from "@fortawesome/react-fontawesome";
+import { getFullImgPath } from "../api/APIUtils";
+import "../css/ImageWithFallback.scss";
+
+/**
+ * Reusable image component which displays a fallback if src is null/undefined
+ */
+function ImageWithFallback({ src, imgSize, mediaType, alt, className }) {
+  if (src) {
+    return <img className={`${className} img-with-fb`} src={getFullImgPath(src, imgSize)} alt={alt} />;
+  }
+
+  let icon;
+  switch (mediaType) {
+    case "movie":
+      icon = "film";
+      break;
+    case "tv":
+      icon = "tv";
+      break;
+    default:
+      icon = "image";
+      break;
+  }
+  return (
+    <div className={`${className} fallback-img`}>
+      <FontAwesomeIcon icon={icon} fixedWidth />
+      <p className="no-img-text">No image</p>
+    </div>
+  );
+}
+
+ImageWithFallback.defaultProps = {
+  src: null,
+  imgSize: "original",
+  alt: "",
+  className: "",
+};
+
+ImageWithFallback.propTypes = {
+  src: PropTypes.string,
+  /* imgSize examples: "w342", "w500" etc */
+  imgSize: PropTypes.string,
+  mediaType: PropTypes.oneOf(["movie", "tv", "person", ""]).isRequired,
+  alt: PropTypes.string,
+  className: PropTypes.string,
+};
+
+export default ImageWithFallback;

--- a/src/components/PosterCard.js
+++ b/src/components/PosterCard.js
@@ -1,26 +1,25 @@
 import React from "react";
 import PropTypes from "prop-types";
-import FontAwesomeIcon from "@fortawesome/react-fontawesome";
 import { Link } from "react-router-dom";
-import { getFullImgPath, getYearFromDate } from "../api/APIUtils";
+import { getYearFromDate } from "../api/APIUtils";
+import ImageWithFallback from "./ImageWithFallback";
 import "../css/PosterCard.scss";
 
 /**
  * Reusable component for showing a movie poster and title
  */
-function PosterCard({ title, posterPath, linkTo, releaseDate }) {
-  const releaseYear = releaseDate ? ` (${getYearFromDate(releaseDate)})` : "";
-
-  let img;
-  if (posterPath) {
-    img = <img className="poster" src={getFullImgPath(posterPath, "w342")} alt={title} />;
-  } else {
-    img = <div className="no-poster"><FontAwesomeIcon icon="image" /></div>;
-  }
+function PosterCard({ title, posterPath, linkTo, releaseDate, mediaType }) {
+  const releaseYear = releaseDate ? ` (${getYearFromDate(releaseDate, "w342")})` : "";
 
   return (
     <Link className="poster-card" to={linkTo}>
-      {img}
+      <ImageWithFallback
+        src={posterPath}
+        imgSize="w342"
+        mediaType={mediaType}
+        alt={`Poster for ${title}`}
+        className="poster"
+      />
       <p className="title">
         {title}{releaseYear}
       </p>
@@ -38,6 +37,7 @@ PosterCard.propTypes = {
   posterPath: PropTypes.string,
   linkTo: PropTypes.string.isRequired,
   releaseDate: PropTypes.string,
+  mediaType: PropTypes.string.isRequired,
 };
 
 export default PosterCard;

--- a/src/components/PosterGrid.js
+++ b/src/components/PosterGrid.js
@@ -19,6 +19,7 @@ function PosterGrid({ movies }) {
             title={movie.title}
             posterPath={movie.poster_path}
             releaseDate={movie.release_year}
+            mediaType={movie.media_type}
           />
         );
       })}

--- a/src/containers/MovieInformationContainer.js
+++ b/src/containers/MovieInformationContainer.js
@@ -91,6 +91,7 @@ class MovieInformation extends Component {
                       title={movie.title}
                       posterPath={movie.poster_path}
                       releaseDate={movie.release_year}
+                      mediaType={movie.media_type}
                     />
                   </div>
                 );

--- a/src/css/DetailsBanner.scss
+++ b/src/css/DetailsBanner.scss
@@ -3,7 +3,8 @@
   height: 365px;
 
   img {
-    object-position: 0 0;
+    // img is centered horizontally, aligned to top vertically
+    object-position: 50% 0;
     object-fit: cover;
     width: 100%;
     height: 100%;
@@ -17,20 +18,4 @@
     right: 0;
     bottom: 0;
   }
-}
-
-.no-poster2 {
-  text-align: center;
-  border-radius: 4px;
-  width: 100% !important;;
-  min-height: 195px;
-  height: 100% !important;
-  background: #eeeeee;
-  font-size: 2em;
-  color: #d3d3d3;
-  display: flex !important;
-  align-items: center;
-  justify-content: center;
-  margin-right:0px !important;
-  margin-left:0px !important;
 }

--- a/src/css/ImageWithFallback.scss
+++ b/src/css/ImageWithFallback.scss
@@ -1,0 +1,25 @@
+// the normal image
+.img-with-fb {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: cover;
+}
+
+// the fallback, with icon and "No image" text
+.fallback-img {
+  background: #eeeeee;
+  font-size: 2em;
+  color: #d3d3d3;
+
+  // center icon and text
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+
+  .no-img-text {
+    font-size: 16px;
+    margin-top: 10px;
+    margin-bottom: 0;
+  }
+}

--- a/src/css/ImageWithFallback.scss
+++ b/src/css/ImageWithFallback.scss
@@ -10,6 +10,7 @@
   background: #eeeeee;
   font-size: 2em;
   color: #d3d3d3;
+  height: 100%;
 
   // center icon and text
   display: flex;

--- a/src/css/PosterCard.scss
+++ b/src/css/PosterCard.scss
@@ -1,29 +1,18 @@
-@mixin poster {
-  border-radius: 4px;
-  width: 100%;
-  min-height: 195px;
-}
-
 .poster-card {
   display: block;
   text-align: center;
   color: inherit;
 
   .poster {
-    @include poster;
-    object-fit: cover;
+    border-radius: 4px;
+    width: 100%;
+    min-height: 195px;
     transition: all 0.2s ease;
+    overflow: hidden;
   }
 
-  .no-poster {
-    @include poster;
+  .poster.fallback-img {
     height: 80%;
-    background: #eeeeee;
-    font-size: 2em;
-    color: #d3d3d3;
-    display: flex;
-    align-items: center;
-    justify-content: center;
   }
 
   .poster:hover {


### PR DESCRIPTION
This PR introduces the `ImageWithFallback` component (please help me come up with a shorter name?) that shows a fallback if the `src` prop is undefined:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/16100194/39587596-2f8b13ae-4efa-11e8-9ba3-3ee5a153707a.png">

<img width="639" alt="image" src="https://user-images.githubusercontent.com/16100194/39587651-4ecaeaf0-4efa-11e8-8771-231b4d446413.png">

fixes #84
