### PR TITLE
Fix normalizeMovie

### DIFF
--- a/src/api/APIUtils.js
+++ b/src/api/APIUtils.js
@@ -36,13 +36,34 @@ export function normalizeMovie(movie) {
   /* eslint-disable camelcase */
   if (movie.isNormalized) return movie;
 
-  const { title, name, release_date, first_air_date } = movie;
-  const mediaType = title ? "movie" : "tv";
+  const {
+    title,
+    name,
+    release_date,
+    first_air_date,
+    media_type,
+    poster_path,
+    profile_path,
+  } = movie;
+
+  let determinedMediaType;
+  if (media_type) {
+    // if the media_type property already exists, no need to
+    // manually determine the media type
+    determinedMediaType = media_type;
+  } else {
+    // only movies have the "title" property
+    // tv and persons have "name" instead
+    determinedMediaType = title ? "movie" : "tv";
+  }
+
   const releaseDate = release_date || first_air_date;
+
   return {
     ...movie,
     title: title || name,
-    media_type: mediaType,
+    media_type: determinedMediaType,
+    poster_path: poster_path || profile_path,
     release_date: releaseDate,
     release_year: releaseDate ? getYearFromDate(releaseDate) : "",
     isNormalized: true,

--- a/src/components/ImageWithFallback.js
+++ b/src/components/ImageWithFallback.js
@@ -29,6 +29,9 @@ function ImageWithFallback({ src, imgSize, mediaType, alt, className }) {
     case "tv":
       icon = "tv";
       break;
+    case "person":
+      icon = "user";
+      break;
     default:
       icon = "image";
       break;

--- a/src/components/PosterGrid.js
+++ b/src/components/PosterGrid.js
@@ -19,7 +19,7 @@ function PosterGrid({ movies }) {
             linkTo={`/${(movie.media_type)}/${movie.id}`}
             title={movie.title}
             posterPath={movie.poster_path}
-            releaseDate={movie.release_year}
+            releaseDate={movie.release_date}
             mediaType={movie.media_type}
             voteAverage={movie.vote_average}
           />

--- a/src/containers/MovieInformationContainer.js
+++ b/src/containers/MovieInformationContainer.js
@@ -91,7 +91,7 @@ class MovieInformation extends Component {
                       linkTo={`/${(movie.media_type)}/${movie.id}`}
                       title={movie.title}
                       posterPath={movie.poster_path}
-                      releaseDate={movie.release_year}
+                      releaseDate={movie.release_date}
                       mediaType={movie.media_type}
                       voteAverage={movie.vote_average}
                     />


### PR DESCRIPTION
The bug was that when `normalizeMovie` was used on the `item` when using drag and drop with PosterCards, the function would incorrectly determine the media_type.

Previously, the media_type was determined by whether the `title` property was defined. If it was defined, it was a movie, since by default only movies have the `title` property. However, the `item` had `title` no matter which media_type it had, since it was already normalized.

The updated function now checks if the `media_type` property already exists, and if it does, no need to manually determine the media type.

When fixing this, I also made it able to determine if it's a person, so profile pictures for actors are now displayed in the search page as well.

fixes #117 