### PR TITLE
Update toast

### DIFF
--- a/src/containers/AddToListBtn.js
+++ b/src/containers/AddToListBtn.js
@@ -72,7 +72,7 @@ class AddToListBtn extends Component {
       if (this.state.statusOfCurrentMovie) {
         updateWatchStatus(movie, selectedList);
         this.setState({ statusOfCurrentMovie: selectedList });
-        infoToast(`${movie.title} moved to ${selectedList}`);
+        infoToast(`${movie.title} moved to ${parseName(selectedList)}`);
       } else {
         await addToList(movie, selectedList);
         successToast(`Added ${movie.title} to ${parseName(selectedList)}`);

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -121,6 +121,7 @@ class App extends Component {
           {sidebarOverlay}
           <ToastContainer
             className="toast-container"
+            toastClassName="toast"
             hideProgressBar
             closeButton={false}
             position="bottom-left"

--- a/src/css/App.scss
+++ b/src/css/App.scss
@@ -18,7 +18,7 @@
   text-align: center;
 }
 
-.toast-success {
-  background: #303030;
-  color: white;
+.toast {
+  padding-top: calc(8px + env(safe-area-inset-bottom) / 2);
+  padding-bottom: calc(8px + env(safe-area-inset-bottom));
 }

--- a/src/utils/toast.js
+++ b/src/utils/toast.js
@@ -1,9 +1,7 @@
 import { toast } from "react-toastify";
 
 export function successToast(text) {
-  toast.success(text, {
-    progressClassName: "toast-progress-bar",
-  });
+  toast.success(text);
 }
 
 export function errorToast(text) {


### PR DESCRIPTION
* Use `parseName` in the update toast in `AddToListBtn`.
* I also added extra padding for iPhone X to the toasts: `env(safe-area-inset-bottom)` is 0 on non-iPhone X, so the toasts' padding is only affected on the iPhone. It looks like this:

Before:
<img width="326" alt="image" src="https://user-images.githubusercontent.com/16100194/40134750-96d50c74-5943-11e8-925c-ecc9190496e0.png">

After:
<img width="319" alt="image" src="https://user-images.githubusercontent.com/16100194/40134760-9edcbd5e-5943-11e8-8334-da983f6aea0d.png">

fixes #139 