### PR TITLE
Fix season bug

### DIFF
--- a/src/containers/EpisodeContainer.js
+++ b/src/containers/EpisodeContainer.js
@@ -53,7 +53,11 @@ class EpisodeContainer extends Component {
 
     let seasonFetch;
     if (seasonNumber === "all") {
-      this.setState({ seasons: {} });
+      // reset all season data
+      this.setState({
+        currentSeason: 1,
+        seasons: {},
+      });
       seasonFetch = getSeasonFromId(id, this.state.currentSeason);
     } else {
       seasonFetch = getSeasonFromId(id, (seasonNumber || 1));


### PR DESCRIPTION
Fixes #163 

The bug was that `currentSeason` wasn't reset when clicking the "All" tab, so if you had scrolled down, `currentSeason` would increment, but since it didn't reset, the fetching function would start at the wrong value.